### PR TITLE
Expose handleClearSelection

### DIFF
--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -283,6 +283,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         this.processSelectionUpdate(true);
     }
 
+    @api
     handleClearSelection() {
         this._curSelection = [];
         this._hasFocus = false;


### PR DESCRIPTION
Add @api decorator to the "Remove selected option" close button. I use lookup with a separate Add button and a datatable. After Adding the selection to the datatable, I need to clear the lookup item. After difficulty finding it in the shadow dom with querySelector and a data-id attribute, this proved to be a much more painless solution! :)